### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/full_test_suite.yml
+++ b/.github/workflows/full_test_suite.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   backend_tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/erikg713/Palace-of-Quests-Quests-on-Pi/security/code-scanning/4](https://github.com/erikg713/Palace-of-Quests-Quests-on-Pi/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions`. Since the workflow only requires read access to the repository contents (e.g., to check out the code), we will set `contents: read` as the minimal required permission. This change ensures that the workflow operates with the least privilege necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
